### PR TITLE
GITHUB: Исключение под CI для модульных папок, правильные Линты

### DIFF
--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -68,6 +68,8 @@ jobs:
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: |
           tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/tgstation_dme.json
+          tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/horizon_dme.json
+          tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/horizon_defines_dme.json
           tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/unit_tests.json
       - name: Check Define Sanity
         if: steps.linter-setup.conclusion == 'success' && !cancelled()

--- a/tools/define_sanity/check.py
+++ b/tools/define_sanity/check.py
@@ -36,6 +36,8 @@ excluded_files = [
     "code/_globalvars/*.dm",
     # TGS files come from another repository so lets not worry about them.
     "code/modules/tgs/**/*.dm",
+    # [HORIZON-ADD]
+    "_horizon/code/__DEFINES/*.dm",
     # Doesn't come with the repo, but is in CI.
     "DMCompiler_linux-x64/*.dm",
 ]

--- a/tools/ticked_file_enforcement/schemas/horizon_defines_dme.json
+++ b/tools/ticked_file_enforcement/schemas/horizon_defines_dme.json
@@ -1,0 +1,7 @@
+{
+    "file": "_horizon/_horizon_defines.dme",
+    "scannable_directory": "_horizon/code/__DEFINES/",
+    "subdirectories": true,
+    "excluded_files": [],
+    "forbidden_includes": []
+}

--- a/tools/ticked_file_enforcement/schemas/horizon_dme.json
+++ b/tools/ticked_file_enforcement/schemas/horizon_dme.json
@@ -1,0 +1,9 @@
+{
+    "file": "_horizon/_horizon_dream.dme",
+    "scannable_directory": "_horizon/",
+    "subdirectories": true,
+    "excluded_files": [],
+    "forbidden_includes": [
+        "_horizon/code/__DEFINES/*.dm"
+    ]
+}

--- a/tools/ticked_file_enforcement/schemas/tgstation_dme.json
+++ b/tools/ticked_file_enforcement/schemas/tgstation_dme.json
@@ -4,6 +4,7 @@
 	"subdirectories": true,
 	"excluded_files": [],
 	"forbidden_includes": [
+        "_horizon/**/*.dm",
 		"code/modules/tgs/**/*.dm",
 		"code/modules/unit_tests/[!_]*.dm",
 		"DMCompiler_linux-x64/*.dm",

--- a/tools/ticked_file_enforcement/ticked_file_enforcement.py
+++ b/tools/ticked_file_enforcement/ticked_file_enforcement.py
@@ -21,6 +21,7 @@ def blue(text):
 schema = json.load(sys.stdin)
 file_reference = schema["file"]
 file_reference_basename = os.path.basename(file_reference)
+file_reference_dir = os.path.dirname(file_reference)
 scannable_directory = schema["scannable_directory"]
 subdirectories = schema["subdirectories"]
 FORBIDDEN_INCLUDES = schema["forbidden_includes"]
@@ -75,7 +76,8 @@ for code_file in scannable_files:
     dm_path = ""
 
     if subdirectories is True:
-        dm_path = code_file.replace('/', '\\')
+        rel_path = os.path.relpath(code_file, file_reference_dir) if file_reference_dir else code_file
+        dm_path = rel_path.replace('/', '\\')
     else:
         dm_path = os.path.basename(code_file)
 


### PR DESCRIPTION
## Описание изменений
- Добавлены отдельные правила для проверки кода в папке Horizon, и настроены исключения для проверок (CI Linters)
- Исправлена работа скрипта для корректного обработки путей во вложенных папках.

## Причина создания ПР / Почему это хорошо для игры
Новая модульная структура теперь полностью поддерживается автоматическими проверками.
Линтеры теперь не будут падать из-за подключения через `.dme` в папке `_Horizon`

## Список изменений
```yml
🆑
config: Настроены проверки, и исключения для папки _Horizon под (CI Linters)
/🆑
```
